### PR TITLE
add attribute for `send_keys` and fix bug in test and sample files

### DIFF
--- a/docs/element_operation.md
+++ b/docs/element_operation.md
@@ -8,9 +8,10 @@
 page.elem.clear()
 """Clears the text if it's a text entry element."""
 
-page.elem.send_keys(value)
+page.elem.send_keys(value, clear_before=False)
 """
 Simulates typing into the element.
+If clear_before is True, it will clear the content before typing.
 """
 
 page.elem.click()

--- a/poium/page_objects.py
+++ b/poium/page_objects.py
@@ -220,12 +220,15 @@ class Element(object):
         logging.info("clear element: {}".format(self.desc))
         elem.clear()
 
-    def send_keys(self, value):
+    def send_keys(self, value, clear_before=False):
         """
         Simulates typing into the element.
+        If clear_before is True, it will clear the content before typing.
         """
         elem = self.__get_element(self.k, self.v)
         logging.info("🖋 input element: {}".format(self.desc))
+        if clear_before:
+            elem.clear()
         elem.send_keys(value)
 
     def click(self):

--- a/sample/u2_demo.py
+++ b/sample/u2_demo.py
@@ -3,13 +3,13 @@ uiautomator2 Library test demo
 https://github.com/openatx/uiautomator2
 """
 import uiautomator2 as u2
-from poium.u2 import Page, PageElement
+from poium.u2 import Page, Element
 
 
 class BBSPage(Page):
-    search_input = PageElement(resourceId="com.meizu.flyme.flymebbs:id/kp", describe="搜索输入框")
-    search_button = PageElement(resourceId="com.meizu.flyme.flymebbs:id/o2", describe="搜索按钮")
-    search_result = PageElement(resourceId="com.meizu.flyme.flymebbs:id/a2a", describe="搜索结果")
+    search_input = Element(resourceId="com.meizu.flyme.flymebbs:id/kp", describe="搜索输入框")
+    search_button = Element(resourceId="com.meizu.flyme.flymebbs:id/o2", describe="搜索按钮")
+    search_result = Element(resourceId="com.meizu.flyme.flymebbs:id/a2a", describe="搜索结果")
 
 
 d = u2.connect()

--- a/tests/test_page_objects.py
+++ b/tests/test_page_objects.py
@@ -8,7 +8,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver, WebElement
 from selenium.common.exceptions import NoSuchElementException
 
-from poium import Page, PageElement, PageElements
+from poium import Page, Element, Elements
 
 @pytest.fixture()
 def webdriver():
@@ -18,14 +18,14 @@ def webdriver():
 class TestConstructor:
 
     def test_page_element(self):
-        elem_id = PageElement(id_='id')
-        elem_name = PageElement(name='name')
-        elem_class = PageElement(class_name='class')
-        elem_tag = PageElement(tag='input')
-        elem_link_text = PageElement(link_text='this_is_link')
-        elem_partial_link_text = PageElement(partial_link_text='is_link')
-        elem_xpath = PageElement(xpath='//*[@id="kk"]')
-        elem_css = PageElement(css='#id')
+        elem_id = Element(id_='id')
+        elem_name = Element(name='name')
+        elem_class = Element(class_name='class')
+        elem_tag = Element(tag='input')
+        elem_link_text = Element(link_text='this_is_link')
+        elem_partial_link_text = Element(partial_link_text='is_link')
+        elem_xpath = Element(xpath='//*[@id="kk"]')
+        elem_css = Element(css='#id')
         assert elem_id.k == 'id_'
         assert elem_name.k == "name"
         assert elem_class.k == "class_name"
@@ -37,22 +37,22 @@ class TestConstructor:
 
     def test_page_element_bad_args(self):
         with pytest.raises(ValueError):
-            PageElement()
+            Element()
         with pytest.raises(ValueError):
-            PageElement(id_='foo', xpath='bar')
+            Element(id_='foo', xpath='bar')
 
 
 class TestGet:
 
     def test_get_unattached(self):
-        assert PageElement(css='bar').__get__(None, None) is None
+        assert Element(css='bar').__get__(None, None) is None
 
 
 class TestSet:
 
     def test_set_multi(self, webdriver):
         class TestPage(Page):
-            test_elems = PageElements(css='foo')
+            test_elems = Elements(css='foo')
 
         page = TestPage(webdriver)
         elem1 = mock.Mock(spec=WebElement)
@@ -98,14 +98,14 @@ class TestRootURI:
 class TestTimeOut:
 
     def test_setting_time_out(self):
-        elem = PageElement(css='foo', timeout=10)
+        elem = Element(css='foo', timeout=10)
         assert elem.k == "css"
 
 
 class TestDescribe:
 
     def test_setting_describe(self):
-        elem = PageElement(name='wd', describe="this is search input")
+        elem = Element(name='wd', describe="this is search input")
         assert elem.k == "name"
 
 


### PR DESCRIPTION
- Add attribute for `send_keys` . A clear action acts before most input action if text exists in input element, so I add this optional attribute for convenience.
- Modify document of `send_keys` 
- Fix some bugs in test and sample files, for `PageElement` had been replaced by `Element`, so as `PageElements`.

A little reward for the useful project at work.